### PR TITLE
Add assembly ops vs numpy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+.pytest_cache/
+*.so
+*.o

--- a/add_arrays.s
+++ b/add_arrays.s
@@ -1,0 +1,78 @@
+section .text
+    global add_arrays
+add_arrays:
+    push rbx
+    mov rbx, rcx
+.loop:
+    cmp rbx, 0
+    je .done
+    mov eax, [rsi]
+    add eax, [rdx]
+    mov [rdi], eax
+    add rsi, 4
+    add rdx, 4
+    add rdi, 4
+    dec rbx
+    jmp .loop
+.done:
+    pop rbx
+    ret
+
+    global sub_arrays
+sub_arrays:
+    push rbx
+    mov rbx, rcx
+.loop_sub:
+    cmp rbx, 0
+    je .done_sub
+    mov eax, [rsi]
+    sub eax, [rdx]
+    mov [rdi], eax
+    add rsi, 4
+    add rdx, 4
+    add rdi, 4
+    dec rbx
+    jmp .loop_sub
+.done_sub:
+    pop rbx
+    ret
+
+    global mul_arrays
+mul_arrays:
+    push rbx
+    mov rbx, rcx
+.loop_mul:
+    cmp rbx, 0
+    je .done_mul
+    mov eax, [rsi]
+    imul eax, [rdx]
+    mov [rdi], eax
+    add rsi, 4
+    add rdx, 4
+    add rdi, 4
+    dec rbx
+    jmp .loop_mul
+.done_mul:
+    pop rbx
+    ret
+
+    global div_arrays
+div_arrays:
+    push rbx
+    mov rbx, rcx
+    mov r8, rdx
+.loop_div:
+    cmp rbx, 0
+    je .done_div
+    mov eax, [rsi]
+    cdq
+    idiv dword [r8]
+    mov [rdi], eax
+    add rsi, 4
+    add r8, 4
+    add rdi, 4
+    dec rbx
+    jmp .loop_div
+.done_div:
+    pop rbx
+    ret

--- a/tensor_ext.c
+++ b/tensor_ext.c
@@ -1,0 +1,127 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+#include <stdlib.h>
+
+extern void add_arrays(int *dest, const int *a, const int *b, long count);
+extern void sub_arrays(int *dest, const int *a, const int *b, long count);
+extern void mul_arrays(int *dest, const int *a, const int *b, long count);
+extern void div_arrays(int *dest, const int *a, const int *b, long count);
+
+static PyObject* pack_recursive(int *data, long *shape, int depth, int shape_len, long offset) {
+    PyObject *list = PyList_New(shape[depth]);
+    if (!list) return NULL;
+    if (depth == shape_len - 1) {
+        for (long i = 0; i < shape[depth]; ++i) {
+            PyObject *item = PyLong_FromLong(data[offset + i]);
+            PyList_SET_ITEM(list, i, item);
+        }
+    } else {
+        long stride = 1;
+        for (int k = depth + 1; k < shape_len; ++k) stride *= shape[k];
+        for (long i = 0; i < shape[depth]; ++i) {
+            PyObject *sub = pack_recursive(data, shape, depth + 1, shape_len, offset + i * stride);
+            if (!sub) { Py_DECREF(list); return NULL; }
+            PyList_SET_ITEM(list, i, sub);
+        }
+    }
+    return list;
+}
+
+static PyObject* build_tensor_fast(PyObject *self, PyObject *args) {
+    PyObject *data_obj, *shape_obj;
+    if (!PyArg_ParseTuple(args, "OO", &data_obj, &shape_obj))
+        return NULL;
+
+    Py_ssize_t shape_len = PyList_Size(shape_obj);
+    Py_ssize_t data_len = PyList_Size(data_obj);
+
+    long *shape = malloc(shape_len * sizeof(long));
+    if (!shape) return PyErr_NoMemory();
+    for (Py_ssize_t i = 0; i < shape_len; ++i) {
+        shape[i] = PyLong_AsLong(PyList_GetItem(shape_obj, i));
+    }
+
+    long tensor_len = 1;
+    for (Py_ssize_t i = 0; i < shape_len; ++i) tensor_len *= shape[i];
+
+    int *data = malloc(tensor_len * sizeof(int));
+    if (!data) { free(shape); return PyErr_NoMemory(); }
+
+    Py_ssize_t copy_len = data_len < tensor_len ? data_len : tensor_len;
+    for (Py_ssize_t i = 0; i < copy_len; ++i)
+        data[i] = (int)PyLong_AsLong(PyList_GetItem(data_obj, i));
+    for (Py_ssize_t i = copy_len; i < tensor_len; ++i)
+        data[i] = 0;
+
+    PyObject *result = pack_recursive(data, shape, 0, (int)shape_len, 0);
+    free(data);
+    free(shape);
+    return result;
+}
+
+static PyObject* binary_op(PyObject *self, PyObject *args,
+                          void (*op)(int*, const int*, const int*, long)) {
+    PyObject *a_obj, *b_obj;
+    if (!PyArg_ParseTuple(args, "OO", &a_obj, &b_obj))
+        return NULL;
+    Py_ssize_t len_a = PyList_Size(a_obj);
+    if (len_a != PyList_Size(b_obj)) {
+        PyErr_SetString(PyExc_ValueError, "length mismatch");
+        return NULL;
+    }
+    int *a = malloc(len_a * sizeof(int));
+    int *b = malloc(len_a * sizeof(int));
+    int *dest = malloc(len_a * sizeof(int));
+    if (!a || !b || !dest) { free(a); free(b); free(dest); return PyErr_NoMemory(); }
+    for (Py_ssize_t i = 0; i < len_a; ++i) {
+        a[i] = (int)PyLong_AsLong(PyList_GetItem(a_obj, i));
+        b[i] = (int)PyLong_AsLong(PyList_GetItem(b_obj, i));
+    }
+    op(dest, a, b, len_a);
+    PyObject *result = PyList_New(len_a);
+    if (!result) { free(a); free(b); free(dest); return NULL; }
+    for (Py_ssize_t i = 0; i < len_a; ++i) {
+        PyObject *item = PyLong_FromLong(dest[i]);
+        PyList_SET_ITEM(result, i, item);
+    }
+    free(a); free(b); free(dest);
+    return result;
+}
+
+static PyObject* add_flat(PyObject *self, PyObject *args) {
+    return binary_op(self, args, add_arrays);
+}
+
+static PyObject* sub_flat(PyObject *self, PyObject *args) {
+    return binary_op(self, args, sub_arrays);
+}
+
+static PyObject* mul_flat(PyObject *self, PyObject *args) {
+    return binary_op(self, args, mul_arrays);
+}
+
+static PyObject* div_flat(PyObject *self, PyObject *args) {
+    return binary_op(self, args, div_arrays);
+}
+
+static PyMethodDef TensorMethods[] = {
+    {"build_tensor_fast", build_tensor_fast, METH_VARARGS, "Build tensor using C/asm"},
+    {"add_flat", add_flat, METH_VARARGS, "Add two flat int lists"},
+    {"sub_flat", sub_flat, METH_VARARGS, "Subtract two flat int lists"},
+    {"mul_flat", mul_flat, METH_VARARGS, "Multiply two flat int lists"},
+    {"div_flat", div_flat, METH_VARARGS, "Divide two flat int lists"},
+    {NULL, NULL, 0, NULL}
+};
+
+static struct PyModuleDef tensormodule = {
+    PyModuleDef_HEAD_INIT,
+    "tensor_ext",
+    NULL,
+    -1,
+    TensorMethods
+};
+
+PyMODINIT_FUNC PyInit_tensor_ext(void) {
+    return PyModule_Create(&tensormodule);
+}
+

--- a/tests/test_numpy_compare.py
+++ b/tests/test_numpy_compare.py
@@ -1,0 +1,70 @@
+import os
+import timeit
+import importlib
+import subprocess
+import sysconfig
+
+import numpy as np
+
+
+def compile_extension():
+    if os.path.exists("tensor_ext.so"):
+        return
+    include = sysconfig.get_paths()["include"]
+    subprocess.check_call(["gcc", "-O3", "-fPIC", "-c", "tensor_ext.c", f"-I{include}", "-o", "tensor_ext.o"])
+    subprocess.check_call(["nasm", "-felf64", "add_arrays.s", "-o", "add_arrays.o"])
+    subprocess.check_call(["gcc", "-shared", "tensor_ext.o", "add_arrays.o", "-o", "tensor_ext.so"])
+
+
+def load_extension():
+    compile_extension()
+    spec = importlib.util.spec_from_file_location("tensor_ext", os.path.join(os.getcwd(), "tensor_ext.so"))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _timed(callable_obj):
+    return timeit.timeit(callable_obj, number=100)
+
+
+def test_operations_against_numpy():
+    tensor_ext = load_extension()
+    a = list(range(10000))
+    b = list(range(1, 10001))
+    np_a = np.array(a, dtype=np.int32)
+    np_b = np.array(b, dtype=np.int32)
+
+    def add_ext():
+        tensor_ext.add_flat(a, b)
+
+    def add_np():
+        (np.array(a, dtype=np.int32) + np.array(b, dtype=np.int32)).tolist()
+
+    def sub_ext():
+        tensor_ext.sub_flat(a, b)
+
+    def sub_np():
+        (np.array(a, dtype=np.int32) - np.array(b, dtype=np.int32)).tolist()
+
+    def mul_ext():
+        tensor_ext.mul_flat(a, b)
+
+    def mul_np():
+        (np.array(a, dtype=np.int32) * np.array(b, dtype=np.int32)).tolist()
+
+    def div_ext():
+        tensor_ext.div_flat(a, b)
+
+    def div_np():
+        (np.array(a, dtype=np.int32) // np.array(b, dtype=np.int32)).tolist()
+
+    assert tensor_ext.add_flat(a, b) == list((np_a + np_b).tolist())
+    assert tensor_ext.sub_flat(a, b) == list((np_a - np_b).tolist())
+    assert tensor_ext.mul_flat(a, b) == list((np_a * np_b).tolist())
+    assert tensor_ext.div_flat(a, b) == list((np_a // np_b).tolist())
+
+    assert _timed(add_ext) < _timed(add_np)
+    assert _timed(sub_ext) < _timed(sub_np)
+    assert _timed(mul_ext) < _timed(mul_np)
+    assert _timed(div_ext) < _timed(div_np)


### PR DESCRIPTION
## Summary
- implement sub, mul, and div assembly routines
- expose operations in `tensor_ext` C extension
- measure performance of ASM routines vs NumPy

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686cff1caf0883208955a2f89b939472